### PR TITLE
#32page/signin&signup

### DIFF
--- a/src/app/api/sign-in/route.ts
+++ b/src/app/api/sign-in/route.ts
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers'
+import { BASE_URL } from '@/definitions'
+
+// 設置每次 request 都獲得最新資料
+export const dynamic = 'force-dynamic'
+
+// api/sign-in
+export async function POST(request: Request) {
+    try {
+        const { account, pwd } = await request.json()
+
+        const response = await fetch(`${BASE_URL}api/v1/user/login`, {
+            method: 'POST',
+            body: JSON.stringify({ account, pwd }),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+        const data = await response.json()
+        if (response.ok) {
+            cookies().set({
+                name: 'token',
+                value: data.data.token,
+                httpOnly: true,
+                path: '/',
+            })
+        }
+        const responseHeaders = new Headers(response.headers)
+
+        return new Response(JSON.stringify(data), {
+            status: response.status,
+            headers: responseHeaders,
+        })
+    } catch (error) {
+        return new Response('Error', { status: 500 })
+    }
+}

--- a/src/components/forms/SignIn/signIn.tsx
+++ b/src/components/forms/SignIn/signIn.tsx
@@ -3,14 +3,14 @@ import React, { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { InputComponent } from '../../common'
-import { useLoginMutation } from '@/services/modules/auth'
 import { useAppDispatch } from '@/hooks/index'
 import { userActions } from '@/stores/slices/userSlice'
+import { useSignInMutation } from '@/services/apiSlice'
 
 export default function SingIn() {
-    const [login] = useLoginMutation()
     const dispatch = useAppDispatch()
     const router = useRouter()
+    const [signIn] = useSignInMutation()
 
     const [username, setUsername] = useState('')
     const [passWord, setPassWord] = useState('')
@@ -25,16 +25,17 @@ export default function SingIn() {
     const handleSubmit = async (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault()
         try {
-            const response = await login({
+            const response = await signIn({
                 account: username,
                 pwd: passWord,
             }).unwrap()
-            console.log('DATA', response)
+
             await dispatch(userActions.login({ ...response }))
-            router.back()
             //TODO: 後續要另外處理身份辨認跳轉到不同頁 ( 後台 or 首頁 )
+            router.back()
             router.push('/')
         } catch (error) {
+            //TODO: alert Error
             console.log('ERROR', error)
         }
     }

--- a/src/components/forms/SignIn/signIn.tsx
+++ b/src/components/forms/SignIn/signIn.tsx
@@ -31,6 +31,7 @@ export default function SingIn() {
             }).unwrap()
             console.log('DATA', response)
             await dispatch(userActions.login({ ...response }))
+            router.back()
             //TODO: 後續要另外處理身份辨認跳轉到不同頁 ( 後台 or 首頁 )
             router.push('/')
         } catch (error) {

--- a/src/definitions/index.ts
+++ b/src/definitions/index.ts
@@ -1,1 +1,1 @@
-export { serverCode } from './server'
+export * from './server'

--- a/src/definitions/server.ts
+++ b/src/definitions/server.ts
@@ -5,4 +5,13 @@ export interface Server {
 // server 自定義狀態碼
 export const serverCode: Server = {
     SUCCESS: '6000',
+    NOT_LOGGED_IN: '6303',
 }
+
+export const BASE_URL = 'https://ticketsystembackend-zz2vrjpjsa-de.a.run.app/'
+
+// 保護路由: 驗證失敗會重導登入頁
+export const protectedRoutes = ['/search']
+
+// 公開路由
+export const publicRoutes = ['/login', '/signup', '/', '/Dashboard']

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,0 +1,27 @@
+import 'server-only'
+import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
+import { BASE_URL, serverCode } from '@/definitions'
+
+// 可在資料請求, Server Actions, Route Handlers, server components 使用 
+export const verifySession = async () => {
+    const token = cookies().get('token')?.value as string
+    try {
+        const response = await fetch(`${BASE_URL}api/v1/user`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            cache: 'force-cache',
+        })
+        const { status, data: userProfile } = await response.json()
+
+        if (!response.ok || status === serverCode.NOT_LOGGED_IN) {
+            redirect('/login')
+        }
+        return { isAuth: true, userProfile }
+    } catch (err) {
+        return { isAuth: false, error: err }
+    }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './session'
+export * from './dal'

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,12 @@
+'use server'
+
+import { Session } from '@/types'
+import { cookies } from 'next/headers'
+
+// 還原 token base64 
+export const getSession = () => {
+    const token = cookies().get('token')?.value.split('.')[1] as string
+    const session: Session = JSON.parse(atob(token))
+
+    return session
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,35 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { BASE_URL, serverCode, protectedRoutes } from '@/definitions'
+import { getSession } from './lib'
 
 export async function middleware(req: NextRequest) {
-    const token = cookies().get('token')?.value
-    const response = await fetch(`${BASE_URL}api/v1/user`, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-        },
-        cache: 'force-cache',
-    }).then((res) => res.json())
-
-    const { status, data: profile } = response
+    const session = getSession()
     const path = req.nextUrl.pathname
     const isProtectedRoute = protectedRoutes.includes(path)
 
-    // 取不到 user info 一律重導回登入頁
-    if (isProtectedRoute && status === serverCode.NOT_LOGGEN_IN) {
+    // 樂觀驗證, 只還原 base64 取 user id , 取不到session 重導回登入頁
+    if (isProtectedRoute && !session?.id) {
         return NextResponse.redirect(new URL('/login', req.url))
     }
 
-    const next_response = NextResponse.next()
-    next_response.cookies.set({
-        name: 'user-profile',
-        value: JSON.stringify(profile),
-        httpOnly: true,
-        path: '/',
-    })
-    return next_response
+    return NextResponse.next()
 }
 
 // match all except specific paths

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { BASE_URL, serverCode, protectedRoutes } from '@/definitions'
+
+export async function middleware(req: NextRequest) {
+    const token = cookies().get('token')?.value
+    const response = await fetch(`${BASE_URL}api/v1/user`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+        cache: 'force-cache',
+    }).then((res) => res.json())
+
+    const { status, data: profile } = response
+    const path = req.nextUrl.pathname
+    const isProtectedRoute = protectedRoutes.includes(path)
+
+    // 取不到 user info 一律重導回登入頁
+    if (isProtectedRoute && status === serverCode.NOT_LOGGEN_IN) {
+        return NextResponse.redirect(new URL('/login', req.url))
+    }
+
+    const next_response = NextResponse.next()
+    next_response.cookies.set({
+        name: 'user-profile',
+        value: JSON.stringify(profile),
+        httpOnly: true,
+        path: '/',
+    })
+    return next_response
+}
+
+// match all except specific paths
+export const config = {
+    matcher: [
+        '/((?!api|_next/static|_next/image|assets|favicon.ico|login|signup).*)',
+    ],
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { cookies } from 'next/headers'
-import { BASE_URL, serverCode, protectedRoutes } from '@/definitions'
+import { protectedRoutes } from '@/definitions'
 import { getSession } from './lib'
 
 export async function middleware(req: NextRequest) {

--- a/src/services/apiSlice.ts
+++ b/src/services/apiSlice.ts
@@ -1,6 +1,44 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { serverCode } from '@/definitions'
 
+// next api endpoint
+export const nextApi = createApi({
+    reducerPath: 'nextApi',
+    baseQuery: fetchBaseQuery({
+        responseHandler: async (response) => {
+            if (response.status === 200) {
+                return response.json().then((data) => {
+                    const { status, message, data: result } = data
+                    // server 自定義錯誤
+                    if (status !== serverCode.SUCCESS) {
+                        return Promise.reject(new Error(message))
+                    }
+                    return result
+                })
+            } else {
+                // http status code error
+                return response.json().then((error) => {
+                    console.log('error', error)
+                    const { status, message } = error
+                    return { status, message }
+                })
+            }
+        },
+    }),
+    endpoints: (builder) => ({
+        signIn: builder.mutation({
+            query: (body) => ({
+                url: 'api/sign-in',
+                method: 'POST',
+                body,
+            }),
+        }),
+    }),
+})
+
+export const { useSignInMutation } = nextApi
+
+// backend api endpoint
 export const api = createApi({
     reducerPath: 'api',
     baseQuery: fetchBaseQuery({
@@ -16,7 +54,6 @@ export const api = createApi({
         },
         timeout: 20000,
         responseHandler: async (response) => {
-            console.log('response', response)
             if (response.status === 200) {
                 return response.json().then((data) => {
                     const { status, message, data: result } = data

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,11 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { api } from '@/services/apiSlice'
+import { api, nextApi } from '@/services/apiSlice'
 import rootReducer from './reducers'
 
 const store = configureStore({
     reducer: rootReducer,
     middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat(api.middleware),
+        getDefaultMiddleware().concat(api.middleware, nextApi.middleware),
 })
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/stores/reducers.ts
+++ b/src/stores/reducers.ts
@@ -1,10 +1,11 @@
 import { combineReducers } from 'redux'
 import userSlice from './slices/userSlice'
-import { api } from '@/services/apiSlice'
+import { api, nextApi } from '@/services/apiSlice'
 
 const rootReducer = combineReducers({
     user: userSlice.reducer,
     api: api.reducer,
+    nextApi: nextApi.reducer,
 })
 
 export default rootReducer

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './button'
+export * from './server'

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,0 +1,6 @@
+export type Session = {
+    id: string
+    accountType: string
+    iat: number
+    exp: number
+}


### PR DESCRIPTION
身份驗證及路由守衛
**因為 middleware 內無法使用 cache，所以改使用 server action 向後端驗證身份**
1. client 端 登入改為 發送給 next server api , 由 next 向 backend 取得資料
2. add middleware 處理 route resquest
3. definitions / server.ts 定義 protectedRoutes , 受保護的路由需要登入
4. 新增 lib資料夾, dal.ts 處理身份驗證 ( 實際向後端驗證 token )
5. middleware 修改為只還原 base64 ( 沒有實際向後端驗證 token )

