### PR TITLE
fix: cart_header

### DIFF
--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -75,7 +75,7 @@ const CartPage = () => {
 
     return (
         <div className="mx-auto max-w-7xl px-6 lg:px-6">
-            <div className="mx-auto max-w-2xl lg:mx-0">
+            <div className="mx-auto mt-6 max-w-2xl lg:mx-0">
                 <h2 className="text-4xl font-bold tracking-wider text-white sm:text-6xl">
                     購物車
                 </h2>


### PR DESCRIPTION
#262 

- fix購物車頁面的標題被 Haader 擋住 
<img width="599" alt="截圖 2024-06-26 上午10 26 56" src="https://github.com/Hexsnorth12/TicketSystem-frontend/assets/61078091/726b951d-d75f-4f2d-b447-adeb3c04a94b">
<img width="599" alt="截圖 2024-06-26 上午10 27 06" src="https://github.com/Hexsnorth12/TicketSystem-frontend/assets/61078091/aa0ffb0e-4dff-4e8c-9352-1dee9b2fc8e2">
